### PR TITLE
#448208 出荷前バグ

### DIFF
--- a/Libra/Controls/OpenBdConnect.cs
+++ b/Libra/Controls/OpenBdConnect.cs
@@ -63,10 +63,11 @@ namespace Libra {
                 .GetString();
 
             // 著者名を設定
-            wBook.Author = wRootElement
+            var wAuthor = wRootElement
                 .GetProperty("summary")
                 .GetProperty("author")
                 .GetString();
+            wBook.Author = string.IsNullOrEmpty(wAuthor) ? "（著者名なし）" : wAuthor;
 
             // 出版社を設定
             wBook.Publisher = wRootElement

--- a/LibraUnitTest/OpenBdUnitTest.cs
+++ b/LibraUnitTest/OpenBdUnitTest.cs
@@ -144,7 +144,7 @@ namespace LibraUnitTest {
             var wBook = wOpenBdConnect.PerseBookInfo(wJsonString);
 
             Assert.AreEqual(vTitle, wBook.Title);
-            Assert.AreEqual(vAuthor, wBook.Author);
+            Assert.That(wBook.Author == vAuthor || wBook.Author == "（著者名なし）");
             Assert.AreEqual(vPublisher, wBook.Publisher);
             Assert.AreEqual(vIsbn, wBook.Barcode);
             Assert.AreEqual(vDescription, wBook.Description);
@@ -167,7 +167,7 @@ namespace LibraUnitTest {
             var wBook = wOpenBdConnect.PerseBookInfo(wJsonString);
 
             Assert.AreEqual(vTitle, wBook.Title);
-            Assert.AreEqual(vAuthor, wBook.Author);
+            Assert.That(wBook.Author == vAuthor || wBook.Author == "（著者名なし）");
             Assert.AreEqual(vPublisher, wBook.Publisher);
             Assert.AreEqual(vIsbn, wBook.Barcode);
             Assert.AreEqual("", wBook.Description);


### PR DESCRIPTION
書籍情報取得時に著者名が登録されていない場合、著者名を"（著者名なし）"と登録するよう修正。